### PR TITLE
Added null safe call to the geometry parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -759,8 +759,8 @@ class ServiceMetadata {
  */
 function toXY(pointGeometry) {
     return {
-        x: pointGeometry.coordinates[0],
-        y: pointGeometry.coordinates[1],
+        x: pointGeometry?.coordinates[0],
+        y: pointGeometry?.coordinates[1],
     }
 }
 


### PR DESCRIPTION
Added null safe operator to geometry object so if the geometry happens to be null, the x and y values with also be null without object access errors.